### PR TITLE
Add hasTokenSync and hasToken methods to check without consuming a token

### DIFF
--- a/lib/fast_ratelimit.js
+++ b/lib/fast_ratelimit.js
@@ -47,43 +47,60 @@ var FastRateLimit = function(options) {
   this.__tokens  = new HashTable();
 };
 
+/**
+ * tokenCheck
+ * @private
+ * @param {boolean} consumeToken Whether the token check also consume one or not
+ * @returns {function} A configured token checking function
+ */
+var tokenCheck = function(consumeToken) {
+  return function (namespace) {
+    // No namespace provided?
+    if (!namespace) {
+      // Do not rate-limit (1 token remaining each hop)
+      return true;
+    }
 
+    let _tokens_count;
+
+    // Token bucket empty for namespace?
+    if (this.__tokens.has(namespace) === false) {
+      _tokens_count = this.__options.threshold;
+
+      this.__scheduleExpireToken(namespace);
+    } else {
+      _tokens_count = this.__tokens.get(namespace);
+    }
+
+    // Check remaining tokens in bucket
+    if (_tokens_count > 0) {
+      if (consumeToken) {
+        this.__tokens.put(
+          namespace, (_tokens_count - 1)
+        );
+      }
+      return true;
+    }
+
+    return false;
+  };
+};
 /**
  * FastRateLimit.prototype.consumeSync
  * @public
  * @param  {string}  namespace
  * @return {boolean} Whether tokens remain in current timespan or not
  */
-FastRateLimit.prototype.consumeSync = function(namespace) {
-  // No namespace provided?
-  if (!namespace) {
-    // Do not rate-limit (1 token remaining each hop)
-    return true;
-  }
+FastRateLimit.prototype.consumeSync = tokenCheck(true);
 
-  let _tokens_count;
+/**
+ * FastRateLimit.prototype.hasTokenSync
+ * @public
+ * @param {string} namespace
+ * @return {boolean} Whether tokens remain in current timespan or not
+ */
 
-  // Token bucket empty for namespace?
-  if (this.__tokens.has(namespace) === false) {
-    _tokens_count = this.__options.threshold;
-
-    this.__scheduleExpireToken(namespace);
-  } else {
-    _tokens_count = this.__tokens.get(namespace);
-  }
-
-  // Check remaining tokens in bucket
-  if (_tokens_count > 0) {
-    this.__tokens.put(
-      namespace, (_tokens_count - 1)
-    );
-
-    return true;
-  }
-
-  return false;
-};
-
+FastRateLimit.prototype.hasTokenSync = tokenCheck(false);
 
 /**
  * FastRateLimit.prototype.consume
@@ -93,6 +110,20 @@ FastRateLimit.prototype.consumeSync = function(namespace) {
  */
 FastRateLimit.prototype.consume = function(namespace) {
   if (this.consumeSync(namespace) === true) {
+    return __Promise.resolve();
+  }
+
+  return __Promise.reject();
+};
+
+/**
+ * FastRateLimit.prototype.check
+ * @public
+ * @param {string} namespace
+ * @return {object} Promise object
+ */
+FastRateLimit.prototype.hasToken = function(namespace) {
+  if (this.hasTokenSync(namespace) === true) {
     return __Promise.resolve();
   }
 
@@ -109,7 +140,7 @@ FastRateLimit.prototype.consume = function(namespace) {
 FastRateLimit.prototype.__scheduleExpireToken = function(namespace) {
   var self = this;
 
-  setTimeout(function() {
+  setTimeout(function () {
     // Expire token storage for namespace
     self.__tokens.remove(namespace);
   }, this.__options.ttl_millisec);

--- a/test/fast_ratelimit-test.js
+++ b/test/fast_ratelimit-test.js
@@ -278,7 +278,82 @@ describe("node-fast-ratelimit", function() {
         launchAsyncFlow(i);
       }
     });
+
+    
   });
+
+  describe("hasTokenSync method", function(){
+    it("should not consume token", function(){
+      var limiter = new FastRateLimit({
+        threshold : 1,
+        ttl       : 10
+      });
+      var namespace = "127.0.0.1";
+
+      assert.ok(limiter.hasTokenSync(namespace), "Limiter hasTokenSync should succeed at hasTokenSync #1");
+      assert.ok(limiter.hasTokenSync(namespace), "Limiter hasTokenSync should succeed at hasTokenSync #2");
+    });
+
+    it("should rate limit", function(){
+      var limiter = new FastRateLimit({
+        threshold : 1,
+        ttl       : 10
+      });
+      var namespace = "127.0.0.1";
+      
+      assert.ok(limiter.hasTokenSync(namespace), "Limiter hasTokenSync should succeed at hasTokenSync #1");
+      assert.ok(limiter.consumeSync(namespace), "Limiter consumeSync should succeed at consumeSync #1");
+      assert.ok(!limiter.hasTokenSync(namespace), "Limiter hasTokenSync should fail at hasTokenSync #2");
+    });
+  });
+    
+    describe("hasToken method", function(){
+      it("should not consume token", function(done){
+        var limiter = new FastRateLimit({
+          threshold : 1,
+          ttl       : 10
+        });
+        var namespace = "127.0.0.1";
+        var promises_all = [];
+
+        promises_all.push(limiter.hasToken(namespace));
+        promises_all.push(limiter.hasToken(namespace));
+
+        __Promise.all(promises_all).then(function(){
+          done();
+        }).catch(function(error) {
+          if(error){
+            done(error);
+          } else {
+            done(
+              new Error("Limiter hasToken should not fail at the end (reject)")
+            );
+          }
+        });
+      });
+
+      it("should rate limit", function(done) {
+        var limiter = new FastRateLimit({
+          threshold : 1,
+          ttl       : 10
+        });
+        var namespace = "127.0.0.1";
+        var promises_all = [];
+
+        promises_all.push(limiter.hasToken(namespace));
+        promises_all.push(limiter.consume(namespace));
+        promises_all.push(limiter.hasToken(namespace));
+
+        __Promise.all(promises_all).then(function(){
+          done(new Error("Limiter hasToken should not succeed at the end (reject)"));
+        }).catch(function(error) {
+          if(error){
+            done(error);
+          }
+          done();
+        });
+      });
+    });
 
   describe("consume method", function() {
     it("should not rate limit", function(done) {


### PR DESCRIPTION
This PR adds 2 methods , sync and async, to check whether a namespace has some remaining token without consuming. This can be used for case like password brute force prevention.

Implements #7 